### PR TITLE
Update defect-classification.json in order to match the dataset

### DIFF
--- a/defect-classification.json
+++ b/defect-classification.json
@@ -203,52 +203,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1bf73a9ca02e8d64fd54aaf8de9ad5d029ebfff775224c3f5b010db80793ea8698863524436d122a100abc08c3486a795eb1caf39f78fc55d3948124861669ac", 
-    "revision": "1_3aef92e687be85047a410b5168f97221c3b831f9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1bf73a9ca02e8d64fd54aaf8de9ad5d029ebfff775224c3f5b010db80793ea8698863524436d122a100abc08c3486a795eb1caf39f78fc55d3948124861669ac", 
-    "revision": "0_37a330e157bc88eb49375eac6ebe8ed6164124cf"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -498,89 +452,10 @@
     "bugclasses": [
       "output mismatch"
     ], 
-    "program": "syllables", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "4_0e0930687d1351ac2bd8a9178887d1a3c5425538"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch"
-    ], 
     "isReferenceDefect": false, 
     "program": "syllables", 
     "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
     "revision": "7_f6c9c4abc8ca8d896236e694ca9207cf101d5fd9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "2_4f9d5d2dc00a0a1a7c3b1d38b38865b37a78b210"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "1_7e5d1c65b36e107351846ba7676f21f796cb06d9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "6_9300f0f13d66f02309d2c032d8b1ea04f1208557"
   }, 
   {
     "bugclasses": [
@@ -605,56 +480,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "8_0f9dcbf2bb193780ee6a6cfcd0f2a8f723c69e9d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "4_25bf7237af187d02b1070c94a5eca1e77975e1fd"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -665,400 +490,12 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "12_9dcaf42b0a605fec11ab0c4075ad36bcf7cc789e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "11_5a447301dda586892e061728f16c5d5291f84553"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "1_423c536859594f90f12b8dd6396bb595c3385aed"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "10_005a5e36d28dac373e02c6a789f272cd6eda3448"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
     "program": "grade", 
     "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
     "revision": "15_17aeee55d4a3f356439c7a41293862d8ef8d78af"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "0_efe4852ec83878415adb0ebbe224450756e0d8ef"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "9_e5976a082d152806f6bf4b71a589bbef3e3c2874"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "3_966d3d583153b15cd8870a53f8835021243d7990"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "5_1a870f4fe7e663dce88944797eb715be616297ec"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "7_1dd920bad8ae43717410231cfc8a876376bfd2e5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "2_41195f448b1a0a75213f1fb433148324cb406c8b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "0_e68c9b3572bc96a43d8579b0ff68c6c262a4dffe"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "3_e37048189422fecc93cae0a6353c909e598de6cc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "2_4f9d5d2dc00a0a1a7c3b1d38b38865b37a78b210"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "1_7e5d1c65b36e107351846ba7676f21f796cb06d9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "4_3bc94b5326e85ca65a9f118d3232a64dce339429"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
-    "revision": "5_7dd78e0a995dc27f101bad6e137b82233e56816e"
   }, 
   {
     "bugclasses": [
@@ -1402,104 +839,12 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
-    "revision": "2_7bed40f4e3d11af16f3091e397b49d0a1c1f6a2b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
-    "revision": "3_e6be37b9ebf6d5c778d5c2001f8145e1c5214a57"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
-    "revision": "5_a7a7596d200465c8a46c881a3cffbaba62e4e361"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "checksum", 
     "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
     "revision": "6_9b87511d0aea229ba69db38b53ff5a6929fb0c28"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
-    "revision": "1_98f0bb857f6dbefe2e919aa6cac60c8c2b8c8dc6"
   }, 
   {
     "bugclasses": [
@@ -1634,29 +979,6 @@
   }, 
   {
     "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "checksum", 
-    "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
-    "revision": "8_87585239d2db0ae34980788f1684e1447cee1333"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
@@ -1752,52 +1074,6 @@
     "program": "checksum", 
     "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
     "revision": "11_f25b6723b3fec173b49485493456b11c3e1f7c36"
-  }, 
-  {
-    "bugclasses": [
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault"
-    ], 
-    "program": "checksum", 
-    "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
-    "revision": "14_2a98ceca7956c0339d6a536e88092892d1a5e6f4"
-  }, 
-  {
-    "bugclasses": [
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault"
-    ], 
-    "program": "checksum", 
-    "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
-    "revision": "9_1f86f340e39c3990ace1c341e283192f009b8012"
   }, 
   {
     "bugclasses": [
@@ -2086,46 +1362,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "2af3c4163b40679ef94bbbbc863c4fa3785c6e164281f5e8850d9e4ffa387e5b162ceb37449ecca33961ff162d861c8d98ff702e723755b6c37c95d5cfaf1c40", 
-    "revision": "9_45fd8565c75243a30f862e0ad5db90db0003dffe"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "2af3c4163b40679ef94bbbbc863c4fa3785c6e164281f5e8850d9e4ffa387e5b162ceb37449ecca33961ff162d861c8d98ff702e723755b6c37c95d5cfaf1c40", 
-    "revision": "10_45c9919bc597e7cc754e3aed905c3668b197f055"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -2180,29 +1416,6 @@
     "program": "syllables", 
     "repo": "2af3c4163b40679ef94bbbbc863c4fa3785c6e164281f5e8850d9e4ffa387e5b162ceb37449ecca33961ff162d861c8d98ff702e723755b6c37c95d5cfaf1c40", 
     "revision": "1_4666a148543924ac27eb7f187a2ddf4e16982ebf"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "2af3c4163b40679ef94bbbbc863c4fa3785c6e164281f5e8850d9e4ffa387e5b162ceb37449ecca33961ff162d861c8d98ff702e723755b6c37c95d5cfaf1c40", 
-    "revision": "1_6f7f766c6d32e669c1f0f651b628d7092d945f53"
   }, 
   {
     "bugclasses": [
@@ -2342,75 +1555,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
-    "revision": "2_ddac892662c0103ee13e1d5365dfc60cd5773842"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
-    "revision": "1_5183664f1aa3e03140964347fc52cb3263951222"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
-    "revision": "3_75600098705cc59c5be8c30530a2fc0ee388b1af"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -2427,31 +1571,6 @@
     "program": "grade", 
     "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
     "revision": "2_78a3dc9aa597455e7418eadc840c02afe97a9a80"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
-    "revision": "0_e22eb9dd66946383be0a7e346a8921782ed38111"
   }, 
   {
     "bugclasses": [
@@ -2514,31 +1633,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "92b7dd1241c2688476a763b691eadd80a1aa750e7c26955f8c3a3d2b11233c05cd51469a029d22c1ba0b6b4203484f2d056d1bdf5cef075f583fbca4292f1a40", 
-    "revision": "1_c108972b60e04e99ef4e42ed2046c9ad26e19a3f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -2554,58 +1648,12 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "659a7300715ba902aeff0650acdfd6e5490cb33ba64d3688555102b2f3f78715368c38fede9c8bb9d23d8041c3db5332ca2877b26bd53f165ff52ceec2022604", 
-    "revision": "0_03a9e35184946bc9172007525d195cf423cd8a8f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "checksum", 
     "repo": "659a7300715ba902aeff0650acdfd6e5490cb33ba64d3688555102b2f3f78715368c38fede9c8bb9d23d8041c3db5332ca2877b26bd53f165ff52ceec2022604", 
     "revision": "3_45b6b2c86131bbf013825b8f341929fd485a1efc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "659a7300715ba902aeff0650acdfd6e5490cb33ba64d3688555102b2f3f78715368c38fede9c8bb9d23d8041c3db5332ca2877b26bd53f165ff52ceec2022604", 
-    "revision": "1_23ca4507129fcc81a95e1ad7fec86ba2b5a05c2b"
   }, 
   {
     "bugclasses": [
@@ -2766,98 +1814,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "fb3110df33e08046594033d067d4b60b96150a419923d92da9cf4e5de1722751a9c9b0bee0f1f60f4fdf925c0aeb9876b76939b12f3f1f72abc49ae61fe68b5e", 
-    "revision": "0_98ef7cb0d3d0725aa6608272763e81331817b65a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "fb3110df33e08046594033d067d4b60b96150a419923d92da9cf4e5de1722751a9c9b0bee0f1f60f4fdf925c0aeb9876b76939b12f3f1f72abc49ae61fe68b5e", 
-    "revision": "3_a65a439d7693eacbf0d5738b8764a3e7d6f8dfe8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "fb3110df33e08046594033d067d4b60b96150a419923d92da9cf4e5de1722751a9c9b0bee0f1f60f4fdf925c0aeb9876b76939b12f3f1f72abc49ae61fe68b5e", 
-    "revision": "1_1feee5eb5ed290f00ce1f9f8ff908fb7636bbd71"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "fb3110df33e08046594033d067d4b60b96150a419923d92da9cf4e5de1722751a9c9b0bee0f1f60f4fdf925c0aeb9876b76939b12f3f1f72abc49ae61fe68b5e", 
-    "revision": "2_8fa42e09dd0df33c9f22fda0666f37475741e003"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -3002,14 +1958,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
-    "revision": "4_fa784cc39921b4f0c958270c95530cbcce122c67"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch", 
       "output mismatch"
     ], 
@@ -3083,58 +2031,12 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
-    "revision": "0_0f083d7274ef37ccf0b1fc519e69bdb45fc407f8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "digits", 
     "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
     "revision": "1_7bd7eafaa4ac764c591703576933a89ca2cfc884"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
-    "revision": "3_c7cf45f1ad5e3e01223ffacf86eaa6ef67f1ceeb"
   }, 
   {
     "bugclasses": [
@@ -3170,29 +2072,6 @@
     "program": "smallest", 
     "repo": "818f8cf4e2e713753d02db9ee70a099b71f2a5a6bdc904191cf9ba68cfa5f64328464dccdd9b02fe0822e14a403dc196fe88b9964969409e60c93a776186a86a", 
     "revision": "3_3a4814b287ca7a95488d3bb1365fedf6cdb808b9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "818f8cf4e2e713753d02db9ee70a099b71f2a5a6bdc904191cf9ba68cfa5f64328464dccdd9b02fe0822e14a403dc196fe88b9964969409e60c93a776186a86a", 
-    "revision": "1_c920c49491848c668e6ffe0a6138a680eb54b95f"
   }, 
   {
     "bugclasses": [
@@ -3384,236 +2263,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "11_5f588afe9fce7a25f855ea6d0a52b731a5e077d9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "3_c36a148c0b02113aedd491a2b90feac08509087e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "4_ed14cce57bc5021db78513a3f00dcd0b851e2793"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "2_264773660f88246075a9f3d6677adaba59c2dfbc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "5_64a9889b38d4d7cff6aba7b6c2ba156c9ac29c77"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "7_661cb36615a7ec6ca11e099a6fb83afe566aef46"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "12_12deabd2489697c5e7c56bb36d2651ccf9383123"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "10_745d9eeed1d09d6a92b1b191ba859303be524715"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "9_47fa01a0efda66efb67209dc6a7bd6916b02901b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "6_bdbf110919a4c3169e0efdbc20e3f61fc8cec35e"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -3648,29 +2297,6 @@
     "program": "digits", 
     "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
     "revision": "0_c8cf619a1b74b7fd173ab8a47d88f40aeccd2972"
-  }, 
-  {
-    "bugclasses": [
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "1391c9b132764431738ca64d39293c8f76de61bab8169ea5e4daf9d14441ee02bf9cf5e448136f7f58d730052ff1c3803688d9e65680d8b757ee1ffdabd4b01f", 
-    "revision": "7_661cb36615a7ec6ca11e099a6fb83afe566aef46"
   }, 
   {
     "bugclasses": [
@@ -3800,127 +2426,12 @@
     "bugclasses": [
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "5_f164eab7f05eca2a97acff932bbe052cc1d3b24a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "checksum", 
     "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
     "revision": "9_f1a13d4313fc0ede0d7429c3d448d7d2dc0f5cd0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "2_d28cf8f427d3dfc3b14a7c922fc26cc5b0fd064a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "3_18c3a08a18f9d1d77298a66ad44d8008b01be4af"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "7_9eb97c3ecc2bdb52c4d3920ca7f7304884f1c6ea"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "1_15cad7a3702084a1f431aa44b20932badfe462a5"
   }, 
   {
     "bugclasses": [
@@ -3936,150 +2447,12 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "4_3767b7d98367922f34b7c5259b38b1a4a94b5c6c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "0_82f43ffba34e903f6a213ed0a9c4db8259a67c36"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
-    "revision": "6_9b01b5000b9619bca76eea465c0bb5b0d93a45a8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "grade", 
     "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
     "revision": "0_fd1eb046f399d81dab21deca31c94096440b6723"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "smallest", 
-    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
-    "revision": "0_ed94da257a84f78eef62c61c66b810ed5af6acff"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
-    "revision": "2_ca9841b1b15187b4c19ef5f8330a52f5cb769368"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
-    "revision": "3_29a40900a9c86286b102659ecfdf5a694f74233d"
   }, 
   {
     "bugclasses": [
@@ -4155,29 +2528,6 @@
     "program": "syllables", 
     "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
     "revision": "0_299dcbd54cb63d62fb4bc2ecc25e916799cd4559"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "checksum", 
-    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
-    "revision": "0_4984350a79496416cb658add1df4b159b07e104f"
   }, 
   {
     "bugclasses": [
@@ -4332,26 +2682,6 @@
     "bugclasses": [
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "1_4c5c94cdec8dc2f5d5f2d4536a7c191ebeef54c2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -4413,118 +2743,6 @@
     "program": "median", 
     "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
     "revision": "3_0a299f8a1c3db120b20795125183187e5f02d7f4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "0_525cb64bdb51bd7d693a280f050c61dc0f4f8719"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "0_af8e28c267550a5e8fc3fa3b9ec561470bc68b19"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "1_aa6262a772f337c55c7a54c7ded0be9a3ad03c64"
-  }, 
-  {
-    "bugclasses": [
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout"
-    ], 
-    "program": "checksum", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "1_c5f941c9f2622be099fb7e1ebde1f828a8d6a9d9"
-  }, 
-  {
-    "bugclasses": [
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout"
-    ], 
-    "program": "checksum", 
-    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
-    "revision": "0_f5298eb36b6ec975b18375e5a420df25f500a2fc"
   }, 
   {
     "bugclasses": [
@@ -4624,206 +2842,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "1_0761b87d37a743397b2cddad3cc8db29a96e694f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "3_5991a189dd87a4f68227ef540313db0813d054ee"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "4_00721999ddca73637f1c1d38e3bf11df307f78b9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "8_34ce1b9ae35a44db73f266762dc2395fd5a45c2c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "0_4d7b5acabbd5b1d93ac40c3c280120a7528e2a5b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "2_bd10aa9a6c93042aa92c7d25bf590b245fa5e9f6"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "9_f1646fff48ac943f2a6faddbe741a8f3426390e4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "7_666021cde9999c3bf8b14c580b0fca058bc3de96"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "5_f301e6d41712eae811707ab69bb9b065c8fec3b2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "496c3f3e943392e789c207a011fb3990033d5a3fb268c226f17ebd241b8fb8c728eb388956fabaa4d764c459a09407ef32d7817dfe4076d1fdab953dd95a8e79", 
-    "revision": "6_b182600eafe8102839e714ddacd56ddacce9ad5c"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -4860,58 +2878,12 @@
   }, 
   {
     "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "digits", 
-    "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
-    "revision": "5_911031e6e4c34e8cc793737ce49f9ea4531cf4aa"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
     "program": "digits", 
     "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
     "revision": "13_4c9d2905705d356f03f105ecd9634b2f598a3400"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
-    "revision": "3_a96db5a4202eae92d4e658b9a3c629e4e937e2d9"
   }, 
   {
     "bugclasses": [
@@ -4925,58 +2897,12 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
-    "revision": "7_a20fd687c270b9328a71d310ce8b11bf7f1bdd8a"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
     "program": "digits", 
     "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
     "revision": "14_c0a46437dc2ab3af3dc3ba1f08c02ecb40eac4b9"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "digits", 
-    "repo": "65e02c1a7db366f566151b090498b01baa8231549ff586b6c37cba7c8951f271f45aca0808dbfe94f7f522878f43ff552458aec08affbb85a4524c37cafa3918", 
-    "revision": "6_8648c21092393c2ea4f7c250720a09feb699b311"
   }, 
   {
     "bugclasses": [
@@ -5238,100 +3164,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
-    "revision": "4_804ccfc319b41be5560cf1c5e595ff1513a2c5f6"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
-    "revision": "3_c0b33dccc87feda64f2f776efa7f2729ce4f817a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
-    "revision": "5_bad529e5292636dab2550eb4b6a35eb87accda0d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
-    "revision": "2_07319b30e3389371070015420564d162b517caa2"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -5396,14 +3228,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
-    "revision": "0_901233e9a0df0dc4fee3320861a8bb7c79f61373"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
@@ -5428,58 +3252,12 @@
     "bugclasses": [
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
-    "revision": "1_f01d382aa5c19cc5277eaa15025e1bdce9da7c24"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "checksum", 
     "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
     "revision": "2_60628b8846d8ddd4ce9700fe190f188dc8030b38"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
-    "revision": "0_b047624cab578c64e6a8b46e71c79fe02c5b9e8f"
   }, 
   {
     "bugclasses": [
@@ -5676,26 +3454,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "9c9308d4cdf5bc5dfe6efc2b1a9c9bc9a44fbff73c5367c97e3be37861bbb3ba9ac7ad3ddec74dc66e34fe8f0804e46186819b4e90e8f9a59d1b82d9cf0a6218", 
-    "revision": "11_e71393fc323c68094ebcdeeaeacb4fe0a9ab29ec"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -5722,26 +3480,6 @@
     "program": "median", 
     "repo": "9c9308d4cdf5bc5dfe6efc2b1a9c9bc9a44fbff73c5367c97e3be37861bbb3ba9ac7ad3ddec74dc66e34fe8f0804e46186819b4e90e8f9a59d1b82d9cf0a6218", 
     "revision": "9_fe03a80bf4d7f0b2b5a86f02fb1d6f15440c5d79"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "median", 
-    "repo": "9c9308d4cdf5bc5dfe6efc2b1a9c9bc9a44fbff73c5367c97e3be37861bbb3ba9ac7ad3ddec74dc66e34fe8f0804e46186819b4e90e8f9a59d1b82d9cf0a6218", 
-    "revision": "10_6a08a64ee453999e4e270f85c6bcf02ff4adff26"
   }, 
   {
     "bugclasses": [
@@ -6001,215 +3739,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "5_46a0b7a090089d82dd153c76b113f9c8f23bff41"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "6_ff736804b2dd0de5365b125b68ae9e4254a99fe1"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "0_b9cb036e6feba24f9e868f86084f34f35d96c6b1"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "1_0ed2eeccf11731c816406885f6691b3bc729141f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "4_cb67cf0930da9371f88097c13109d128ebb47529"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "2_3fcf8d86df6d7b77a2164018edf12f822cfdb706"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "7_29a939285e4c9256d3c4208e63ff984d88049a94"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "3_e6c419d1086e4de0a60e8f223d85852a01e91e40"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "846021256d8ee8e5398346b8c049a0489ee71209518b971ce1d11e81406bfea1bb78c99c339660ac2790d61d438ecae0ff7a35bfab07864f8e6f69ca2450013c", 
-    "revision": "1_1f1bd79d028b943810cb6d6180c2d78d2a23e156"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -6238,52 +3767,6 @@
     "program": "checksum", 
     "repo": "2c1556672751734adf9a561fbf88767c32224fca14a81e9d9c719f18d0b21765038acc16ecd8377f74d4f43e8c844538161d869605e3516cf797d0a6a59f1f8e", 
     "revision": "4_65e15660119777a6c39604ebe66a634bb7e366a6"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "2c1556672751734adf9a561fbf88767c32224fca14a81e9d9c719f18d0b21765038acc16ecd8377f74d4f43e8c844538161d869605e3516cf797d0a6a59f1f8e", 
-    "revision": "1_d7574906e85a4d85177317d86b43d7aed826b7d2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "2c1556672751734adf9a561fbf88767c32224fca14a81e9d9c719f18d0b21765038acc16ecd8377f74d4f43e8c844538161d869605e3516cf797d0a6a59f1f8e", 
-    "revision": "0_8af355cada3a2df66ca223dbd3c0056ac057f7af"
   }, 
   {
     "bugclasses": [
@@ -6381,144 +3864,6 @@
     "program": "syllables", 
     "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
     "revision": "0_69aa3c9b5f36d72304e5f0480d5fab6d482a9961"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "3_5fa052b9fd5fcdbe034c6139001dd32010e52180"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "1_35f38a9f3cf45f9df910808c8ac4ebd83770e8b7"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "5_f85f204bbc4fcda13eb5a3ba64d05b4c0161b4b4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "6_e7e762523d4cb2fc42a9d69889ebcdfba68bf920"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "2_4445cc4dfa6ad2d98e32e222e2802fc2d7c3664d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
-    "revision": "4_a1a267744d2a1d3c4e50562eed53e0ee5f231894"
   }, 
   {
     "bugclasses": [
@@ -6856,29 +4201,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "output mismatch", 
-      "segfault", 
-      "output mismatch", 
-      "output mismatch", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "output mismatch", 
-      "segfault"
-    ], 
-    "program": "checksum", 
-    "repo": "3214e9b00d4375825f24621cd10fc694ef14afa5a94ce0db9dac20877a21ea2d4b3594007d52464e0cea55e5ed3bb188712a67d8d002c1f28917057057120605", 
-    "revision": "2_2b9a049daae878ff7b364cbb498b1e7f44991339"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
@@ -7017,98 +4339,6 @@
     "program": "digits", 
     "repo": "ca5057661022789c0b40bc1574ab8b0826b3d22f70de1a10b2d2122137774c6aec73fe789a94b2362628481da623120033956bd376b41b825a72dbd8b50aff2f", 
     "revision": "0_2cc307311291e97126f6698fb231bfe12162866a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "a3d1771781cb82fd72bf708693ced00fccbec480c21c0e0dca5a3843fff6dfb92d3e68fc6d992cc7b76987e706875c6570936cb127216a3a8b437feba7772d14", 
-    "revision": "3_1d75dfd2c85dfd98f942d5b8486616887cdc7993"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "a3d1771781cb82fd72bf708693ced00fccbec480c21c0e0dca5a3843fff6dfb92d3e68fc6d992cc7b76987e706875c6570936cb127216a3a8b437feba7772d14", 
-    "revision": "0_5514269b703234098ec663cb9d9bad653107e9fb"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "a3d1771781cb82fd72bf708693ced00fccbec480c21c0e0dca5a3843fff6dfb92d3e68fc6d992cc7b76987e706875c6570936cb127216a3a8b437feba7772d14", 
-    "revision": "2_3223573828fc38c8ed4b4d3b48615e1e0ded1d15"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "a3d1771781cb82fd72bf708693ced00fccbec480c21c0e0dca5a3843fff6dfb92d3e68fc6d992cc7b76987e706875c6570936cb127216a3a8b437feba7772d14", 
-    "revision": "1_fdda6bf846c3ed943297a1bdb4b2cd20667f2d2b"
   }, 
   {
     "bugclasses": [
@@ -7285,75 +4515,6 @@
     "program": "grade", 
     "repo": "b1924d63a2e25b7c8d9a794093c4ae97fdceec9e0ea46b6a4b02d9a18b9ba9cecf07cb0c42c264a0947aec22b0bacff788a547a8250c2265f601581ab545bf82", 
     "revision": "0_4f355de83b58d3dd56ac3bfdeccc0575f537f352"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "833bd42c11f7407d63f604b8ba3b7927e22e04e91884c959f01083cda7d5019610705b94a89c09cd1caa3fd1d58eee24b48b85b523db0fa3fc302e7af2dff93d", 
-    "revision": "1_d256117050418224079b9c307df45fd0b5f78aa8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "833bd42c11f7407d63f604b8ba3b7927e22e04e91884c959f01083cda7d5019610705b94a89c09cd1caa3fd1d58eee24b48b85b523db0fa3fc302e7af2dff93d", 
-    "revision": "0_294d349b487934e7f16cebe4f584ca7ca71dbf68"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "833bd42c11f7407d63f604b8ba3b7927e22e04e91884c959f01083cda7d5019610705b94a89c09cd1caa3fd1d58eee24b48b85b523db0fa3fc302e7af2dff93d", 
-    "revision": "2_c7f5af397f819871e863390d39e5a11d4aeec66b"
   }, 
   {
     "bugclasses": [
@@ -7628,52 +4789,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "90a14c1ac8f56395389fade6f67872a9684e61f83099e634ac675eae04f391f3cc2b6f6ebe966f2488ce7e00a2cabb218f3b1372d4161b3c05d134b1b7f296d2", 
-    "revision": "2_fc889459bea6438b4f55815177541cd9856bd4a5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "90a14c1ac8f56395389fade6f67872a9684e61f83099e634ac675eae04f391f3cc2b6f6ebe966f2488ce7e00a2cabb218f3b1372d4161b3c05d134b1b7f296d2", 
-    "revision": "1_64bada744b43832aa26b5cee593d6f6213ba8a6c"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -7707,29 +4822,6 @@
     "program": "digits", 
     "repo": "90a14c1ac8f56395389fade6f67872a9684e61f83099e634ac675eae04f391f3cc2b6f6ebe966f2488ce7e00a2cabb218f3b1372d4161b3c05d134b1b7f296d2", 
     "revision": "1_64bada744b43832aa26b5cee593d6f6213ba8a6c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "3_8342cfa415de377a63f764c62001d04eb3449be8"
   }, 
   {
     "bugclasses": [
@@ -7916,156 +5008,12 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "4_aecf18e2e79f05acfa08809af231a4074bdb9bf6"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "3_6a5f5058e7fb278ceba739425e964955c551f7a0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "2_d1ba55f02f2ee748d5b9b242b3e732d4e2e40b81"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "1_c97c3278e6daf182b3186c295cb63ebab83e2491"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "grade", 
     "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
     "revision": "9_7f4bf3bf4cac96cfa5bb94fb76e9c717a677458f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "6_30a16043feb4b7d8dd3a24fbd8ab54094e3165bc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "5_82cfb5bc8d4c8c20b0129bc67c0021b3c19d6293"
   }, 
   {
     "bugclasses": [
@@ -8080,162 +5028,12 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "3_8950becfc02b20a03fd8412ea1e9afe7a8fe2e5c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "12_2f33388712e965e9f3c5abef9e41518f11272d86"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "7_b94e86a76a0cbbea96faed01396e2aab93be6cf9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "grade", 
     "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
     "revision": "10_3dc9b48dc02661443040e775758073284a1b0752"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "4_f63f35d7a981c1c48ef5a2a0107443a755a9bfa5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "2_b51d96f118b2737b6d0729f3d48a04592635d42f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
-    "revision": "8_ed69f3ead94e62c2424be4c44b9b20bf9facb966"
   }, 
   {
     "bugclasses": [
@@ -8310,144 +5108,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "1_62268609e3b0172ec400eccaa7cc7066c76053d0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "2_618c1cfba6ad3962fd0f12e8cb1518d61338a59f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "5_5e52412712a3245cb8b89dd0104f2d7962455f6a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "0_cacbc4eabc1d8538f3c1dc6f9e6ee25a63daf655"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "3_441e24855694edb9028fea654946b01e965b771e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ff9fd0121ba04286bbb31ccbf49a31c36b639f4459714ff947b151cfd3f21e0038411e980a053f57b3239069a95e2795107c0978eea647d7daec84e58a4975a0", 
-    "revision": "4_b48610d89d01f23b4097660807a58bb3acf5e437"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -8502,52 +5162,6 @@
     "program": "syllables", 
     "repo": "f5b56c79c624eac7c37c45c1540916bb9b5f5db93e2a426a282a5d0eacde86b4b1e5d1d119eeb06f0ead94d2e4f228dca8dde4ef511af4bc59a18d272d820a0e", 
     "revision": "2_98507a1f386c525de19ce8a5404f6915fe4182c3"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "f5b56c79c624eac7c37c45c1540916bb9b5f5db93e2a426a282a5d0eacde86b4b1e5d1d119eeb06f0ead94d2e4f228dca8dde4ef511af4bc59a18d272d820a0e", 
-    "revision": "6_a89d3411baffe658b9d34199bfd531da03af88f7"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "f5b56c79c624eac7c37c45c1540916bb9b5f5db93e2a426a282a5d0eacde86b4b1e5d1d119eeb06f0ead94d2e4f228dca8dde4ef511af4bc59a18d272d820a0e", 
-    "revision": "7_4ff6a016fb8b1f55509fd126a1539c25368f2bff"
   }, 
   {
     "bugclasses": [
@@ -8775,75 +5389,6 @@
     "program": "median", 
     "repo": "e9c6206d3a4862876b0dead881ac55078f11e291f60215ab028651f06fcbee2a591a31a7727037774542df4fe051a89460d85f6067a0b9729ae86e4afe1e6e92", 
     "revision": "0_fc0215f05d1e7ea83d743eb27f864b69c1f325a8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e9c6206d3a4862876b0dead881ac55078f11e291f60215ab028651f06fcbee2a591a31a7727037774542df4fe051a89460d85f6067a0b9729ae86e4afe1e6e92", 
-    "revision": "1_994c7d2d2690a99a66a53624e018b1a1dc60bcd1"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e9c6206d3a4862876b0dead881ac55078f11e291f60215ab028651f06fcbee2a591a31a7727037774542df4fe051a89460d85f6067a0b9729ae86e4afe1e6e92", 
-    "revision": "0_f428ddb651665d35b347130054cb11ed3e463341"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e9c6206d3a4862876b0dead881ac55078f11e291f60215ab028651f06fcbee2a591a31a7727037774542df4fe051a89460d85f6067a0b9729ae86e4afe1e6e92", 
-    "revision": "2_458f6db12a74f1f4deb9a732c273b9b5398f64db"
   }, 
   {
     "bugclasses": [
@@ -9194,75 +5739,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "fbb23c249df3bd3d3a2b8a2cecf5242244e7841c7e0520fc7e8bb5c8981d1e64718acb7f2010b05f4d6734c15cb6a9956e1ed1d31d48a7590e2c48b054882041", 
-    "revision": "1_d5a747441f775016ec29364da81ad76b82e095e4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "fbb23c249df3bd3d3a2b8a2cecf5242244e7841c7e0520fc7e8bb5c8981d1e64718acb7f2010b05f4d6734c15cb6a9956e1ed1d31d48a7590e2c48b054882041", 
-    "revision": "2_dda6284f6ca2b20ba390480398433fd07b557d95"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "fbb23c249df3bd3d3a2b8a2cecf5242244e7841c7e0520fc7e8bb5c8981d1e64718acb7f2010b05f4d6734c15cb6a9956e1ed1d31d48a7590e2c48b054882041", 
-    "revision": "0_e7b1271d4a8dd3cd9d76560b69f0bc38447be09b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -9528,98 +6004,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
-    "revision": "3_3d73551298331055d774a6d69fd2af8a0de7d930"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
-    "revision": "4_079333746a7cb273241b2c469b7e7be93531a872"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
-    "revision": "5_d808c4546eea004b64af96024e713cfbf8517639"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
-    "revision": "6_43763a717b1f99e3da46ed9c95693fc83c445925"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -9646,31 +6030,6 @@
     "program": "grade", 
     "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
     "revision": "3_ea1bdbb838fb7ff3e9177d744667858df353a62b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
-    "revision": "0_7fd9b3fe01f347502fe9d0dbe861ccc2249a5710"
   }, 
   {
     "bugclasses": [
@@ -9844,14 +6203,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "d6364e6e98a5c96387950d5b3e6206ba9d57628ab2ad0f2cd05ea7af3b818ed03e514157fe4c64e264a0ac9df0840028e0c5a8fd3d096f5ab93bffba61f23812", 
-    "revision": "1_a8500f46ecc8a2b6427cb1b48a5dbf11268eb1b6"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
@@ -9873,72 +6224,12 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "d6364e6e98a5c96387950d5b3e6206ba9d57628ab2ad0f2cd05ea7af3b818ed03e514157fe4c64e264a0ac9df0840028e0c5a8fd3d096f5ab93bffba61f23812", 
-    "revision": "2_2e2031577cdc6fc1541e7be9304a567f0158226b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "median", 
     "repo": "d6364e6e98a5c96387950d5b3e6206ba9d57628ab2ad0f2cd05ea7af3b818ed03e514157fe4c64e264a0ac9df0840028e0c5a8fd3d096f5ab93bffba61f23812", 
     "revision": "5_b600df06fb98d3672152d1cec381e3922f11486a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "d6364e6e98a5c96387950d5b3e6206ba9d57628ab2ad0f2cd05ea7af3b818ed03e514157fe4c64e264a0ac9df0840028e0c5a8fd3d096f5ab93bffba61f23812", 
-    "revision": "3_6c2bd30025a1753e6decf04160bf0162bd125ddb"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "d6364e6e98a5c96387950d5b3e6206ba9d57628ab2ad0f2cd05ea7af3b818ed03e514157fe4c64e264a0ac9df0840028e0c5a8fd3d096f5ab93bffba61f23812", 
-    "revision": "4_b2fdfde3be6829d2ea79e5972a836fb6bc8b9e50"
   }, 
   {
     "bugclasses": [
@@ -10337,52 +6628,6 @@
   }, 
   {
     "bugclasses": [
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout"
-    ], 
-    "program": "checksum", 
-    "repo": "e79f832ff314d3658c07e164d7866db707eafc8c97f209cf1d5cdb3b0cfc6738e7bd533c426a4887122d853ffa152b8861f30c41642a180152ba50c983de66dc", 
-    "revision": "0_2c509bb4d7126aa65150c5d2db17efba7da05701"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e79f832ff314d3658c07e164d7866db707eafc8c97f209cf1d5cdb3b0cfc6738e7bd533c426a4887122d853ffa152b8861f30c41642a180152ba50c983de66dc", 
-    "revision": "1_26496ae8216b958272c213649f83121daa5e3f50"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -10452,71 +6697,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
-    "revision": "0_7ebbec060b5c0ec97537beb36afba9bf1a71f116"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
-    "revision": "1_7b3b25ea55eb89a8bf6f1791565972203fbdb93d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
-    "revision": "2_0a444961b6f105a0f5f0383a6d4c1144c8c8480d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch", 
       "output mismatch"
     ], 
@@ -10524,56 +6704,6 @@
     "program": "grade", 
     "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
     "revision": "3_459bc2c673390c921215e2290c18508780d278e3"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
-    "revision": "0_7ebbec060b5c0ec97537beb36afba9bf1a71f116"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
-    "revision": "1_7b3b25ea55eb89a8bf6f1791565972203fbdb93d"
   }, 
   {
     "bugclasses": [
@@ -10700,52 +6830,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ea67b84145a12733c524b716da44f36a42cf815013d14cafbd2a66a5a4c8b5a99022c355960cd62ca71a640315747cd604afdfa9ec753d1739c686734b2798a7", 
-    "revision": "5_946682feb5a73f666ec36f4b6caf16e62b4d637c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ea67b84145a12733c524b716da44f36a42cf815013d14cafbd2a66a5a4c8b5a99022c355960cd62ca71a640315747cd604afdfa9ec753d1739c686734b2798a7", 
-    "revision": "1_98353b84821d198cf917ef1c78dedc6ba1c94ab8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -10896,29 +6980,6 @@
     "program": "median", 
     "repo": "aaceaf4ad658a90db957967d2852b7dfa81b42f4ab8dbdf2f7c9847a6072e1741a6b0cbd2ea52f5669f2da1cdf925ec565d257320cf93b97bc9bc99f000e1871", 
     "revision": "5_be4a7b75f175f3057a69e5bb7ff5110e7bc58940"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
-    "revision": "5_cc6f4e1b3d663c9dee761ce1f95b5044d2c94337"
   }, 
   {
     "bugclasses": [
@@ -10939,98 +7000,6 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
-    "revision": "4_dfce7648398f2faf6892feb28b8d293ac3679955"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
-    "revision": "3_bd6c4079461358402fedba85044b5a27a137615b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
-    "revision": "1_ecf67be8fbf53c99d1b46468f6b2ffcd795825fb"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
-    "revision": "0_ee02b2fc835622f36995b7d48320afac1419535a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -11047,52 +7016,6 @@
     "program": "grade", 
     "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
     "revision": "1_921130be5036484379ee4a6f5d339bdae7576aa1"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e23b96b6bab26bd14316cefafcbaa16dd8eafcfb97a7159a7772f3c8bb3e78fb353dea728f6b4df6528286af5f0b85fd134c79886c9c2a352fe80d8204c69111", 
-    "revision": "2_f1aa9096cd4242467eb864e0a475eff1c2c510f0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "e23b96b6bab26bd14316cefafcbaa16dd8eafcfb97a7159a7772f3c8bb3e78fb353dea728f6b4df6528286af5f0b85fd134c79886c9c2a352fe80d8204c69111", 
-    "revision": "1_17639194180944892d80fc9bd1ef1cb5bb0725b2"
   }, 
   {
     "bugclasses": [
@@ -11344,158 +7267,12 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "3_4e9cc79ff3b24382dbceec4c0aaccd75c115cf3a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "3_582223ffb58647ef141b14f093474d46aa4e732d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "5_e81ebbc6e762c94b709760f0c4653f6d7785f6c2"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "median", 
     "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
     "revision": "7_b392eab4dc09b4f7d01312e61d3ee88d3249fe77"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "2_9fc08dec6f493c85a20ceb16dbbed3118ab2025b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "4_a432d8ebd483dd21e499875eb5d289871996c1cd"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "6_a1964052706d6cd5b7ff4ceaa4c62f71f78768e4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "0_3da0bc6510d07721ed44349a4e00e105a7749eb0"
   }, 
   {
     "bugclasses": [
@@ -11592,144 +7369,6 @@
     "program": "syllables", 
     "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
     "revision": "2_621eace1e2f8b1d74531312c020ca4e02f8d4101"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "1_ee5438fa44cf14cce1fb4504ea259277ae398c15"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "0_e489633080a5b1fce32c53691351a0d2a30ad20d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "2_69a02643a3ab4336b0b22f46fea7c23548454893"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "3_c1a8346dc22871d3295c834b11b509b0954fe560"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "4_da3f43bbb6d79227696654743d8d6e0af29a1b1a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
-    "revision": "1_eac57d8063fc0a94294d07a3d3816fb8262962f8"
   }, 
   {
     "bugclasses": [
@@ -12089,98 +7728,6 @@
     "program": "syllables", 
     "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
     "revision": "1_87286ca6af828531e43ac41a9baef15b9e1bedd5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
-    "revision": "2_c75e3c10f6746f2e9d6d130e0bbbaa96c770c83f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
-    "revision": "3_196bccfb87a69cf1118750b367c7e057f1ef12bd"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "checksum", 
-    "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
-    "revision": "1_217a866aa1761b504532c62c4d1f647d95111e17"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "checksum", 
-    "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
-    "revision": "0_31288b98609380ae8680ebd924a0659e4b06a59a"
   }, 
   {
     "bugclasses": [
@@ -12557,29 +8104,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "1c2bb3a40a82cba97b2937bc6825903a28ecfe91f993fc177a0f2ae003bcc7b1073eb49e35d3f0f69d6b612e8347e9c1b93306bf25a7e5390098c1a06845baac", 
-    "revision": "4_ff87e74d18c0df54fd2f0faaafb29f456598c155"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -12736,29 +8260,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "fcf701e8bed9c75a4cc52a990a577eb0204d7aadf138a4cad08726a847d66e77126f95f06f839ec9224b7e8a887b873fe0d4b6f4311b4e8bd2a36e5028d1feca", 
-    "revision": "1_3da9550787d9f0ba9cf4973f880e5f4bf1d1a776"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -12774,83 +8275,12 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "fcf701e8bed9c75a4cc52a990a577eb0204d7aadf138a4cad08726a847d66e77126f95f06f839ec9224b7e8a887b873fe0d4b6f4311b4e8bd2a36e5028d1feca", 
-    "revision": "2_e4b9b5dbca9776194801817c3906b27876c95af4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "median", 
     "repo": "d2b889e1ac42bc85f9df5c45c10708f46784be93d69acd1415cfd4d028cb50b19f50c374a9498c8e8b909173053a100e20c279ddb06c6359a06a920ead3e8080", 
     "revision": "0_c820448b4beba882f8b5d96af1ce7844f47b50af"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "d2b889e1ac42bc85f9df5c45c10708f46784be93d69acd1415cfd4d028cb50b19f50c374a9498c8e8b909173053a100e20c279ddb06c6359a06a920ead3e8080", 
-    "revision": "0_c820448b4beba882f8b5d96af1ce7844f47b50af"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "d2b889e1ac42bc85f9df5c45c10708f46784be93d69acd1415cfd4d028cb50b19f50c374a9498c8e8b909173053a100e20c279ddb06c6359a06a920ead3e8080", 
-    "revision": "2_e84303dd39425109e6e0e1be6c35c499a802ace3"
   }, 
   {
     "bugclasses": [
@@ -13181,29 +8611,6 @@
     "program": "median", 
     "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
     "revision": "3_f025012692680d97912189bcf1a180c43e9dc1a0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
-    "revision": "1_18614adf1af4917b4eeb3924ca9056e70e021a7d"
   }, 
   {
     "bugclasses": [
@@ -14051,81 +9458,12 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
-    "revision": "1_db969fe125441d3bffa75a85e1ebe8f099a08707"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "digits", 
     "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
     "revision": "3_1c69bfa2fa6ec6cd5d57f6a9fd73f44d5e7f0349"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
-    "revision": "2_afa7016f90e1057fed73447e8dfffc14611ad3db"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
-    "revision": "0_5f28e1f2f564fb11eee32014c6b0fb10a806a904"
   }, 
   {
     "bugclasses": [
@@ -14149,190 +9487,12 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "0_da7f57e8e0cb13cf3ed379c1cc77d416838a076f"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "median", 
     "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
     "revision": "2_1afe0eef1d5a8f3e33764ba368e51cc3a70edacf"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "1_3ab4e9a491d1968c525f901c03fbfe4a6a6b097f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "7_97e76f4f7380886df140c1399d249cac842bb57e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "6_b171f29e2c4dea2746cb2892ff7ff64eddb59051"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "5_5af21b19fefd03faf35c99c691b5697a09bdbff4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "9_5006b75b0e1b70ac79ba49997ee5ee27e57cf415"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "8_9f65955478086e1afdf709dd78098e10f45ecdf4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
-    "revision": "4_861fcdb56f6863a6e8276adab7e226a2b35a700c"
   }, 
   {
     "bugclasses": [
@@ -14401,23 +9561,6 @@
     "program": "syllables", 
     "repo": "7b78b2d5ab654253c4acb32046237950862d20275165bdb24a7584184a22d3cebeadb299f4e16fdf452f4dc6f958000d118d5ba60dea5645d143183573109d58", 
     "revision": "7_63ee307fbb02b2de42d1b51000ec4d9755790025"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "7b78b2d5ab654253c4acb32046237950862d20275165bdb24a7584184a22d3cebeadb299f4e16fdf452f4dc6f958000d118d5ba60dea5645d143183573109d58", 
-    "revision": "4_b17bfba14cf2bc2e9138ed28a2d1045e6121356f"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "7b78b2d5ab654253c4acb32046237950862d20275165bdb24a7584184a22d3cebeadb299f4e16fdf452f4dc6f958000d118d5ba60dea5645d143183573109d58", 
-    "revision": "6_8f4f0fbbb672d6dade38a7e623b511e1df64c2b0"
   }, 
   {
     "bugclasses": [
@@ -14522,29 +9665,6 @@
     "program": "syllables", 
     "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
     "revision": "0_cbd31b14ec1598ed26e9e56c0079319595170a9b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
-    "revision": "2_aaa776726bb213774e871c40dc9e592538fad3cb"
   }, 
   {
     "bugclasses": [
@@ -14693,75 +9813,6 @@
   }, 
   {
     "bugclasses": [
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault"
-    ], 
-    "program": "checksum", 
-    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
-    "revision": "1_86d5edb0eb4ddaacc8f58a0c80bfad6a6bafefc3"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
-    "revision": "2_267bb359526ef4e78ebb87e5a01cb06ec820063e"
-  }, 
-  {
-    "bugclasses": [
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault", 
-      "segfault"
-    ], 
-    "program": "checksum", 
-    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
-    "revision": "0_9299436d2208aeb1d7c39c48ebb063e163573a02"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch", 
       "output mismatch", 
       "output mismatch"
@@ -14770,29 +9821,6 @@
     "program": "checksum", 
     "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
     "revision": "4_6ea9dcde6a37382529bc55eb1d1ec27cbd0e5ccd"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
-    "revision": "3_f3d3d37912333005baed4f6954c78b30889b82b1"
   }, 
   {
     "bugclasses": [
@@ -15045,121 +10073,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
-    "revision": "5_26437d6979541bd7f2215a50ffa145522ec4f43b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
-    "revision": "0_4da69ee30c349a02254ca90ce50b47f5c6d9ddb2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
-    "revision": "1_3b46ddfc9e328f9c00b26bf663aa62d3750725c2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
-    "revision": "4_5aced9dc3b63e6c3bec34704e2852973681f32fd"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
-    "revision": "2_9a29da475fa8372d8bf93eef5606a985333a4070"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -15285,52 +10198,6 @@
   }, 
   {
     "bugclasses": [
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout", 
-      "timeout"
-    ], 
-    "program": "checksum", 
-    "repo": "c716ee619761838749589cbd08d5fd56830bff349039f8587e988a5b0cd6310e04844d8e0ee98c5ffee3275aa227bd2c92fcde0993637fcf3bfbd41a37378833", 
-    "revision": "1_ea413ecde8e8b6685b5d153f12df6875de659ca0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "c716ee619761838749589cbd08d5fd56830bff349039f8587e988a5b0cd6310e04844d8e0ee98c5ffee3275aa227bd2c92fcde0993637fcf3bfbd41a37378833", 
-    "revision": "0_16b5287798c537ba908d0e8bb8cd1246d9b454df"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -15403,29 +10270,6 @@
     "program": "smallest", 
     "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
     "revision": "10_2d9b8df5b0419a4949be88cabca07e41945e8096"
-  }, 
-  {
-    "bugclasses": [
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other", 
-      "other"
-    ], 
-    "program": "smallest", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "1_fe1d358a919b140865dd002be77e4f42db0ac543"
   }, 
   {
     "bugclasses": [
@@ -15525,52 +10369,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "2_8a3ac8d492947fb9035db038d133493f62d2c117"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "1_5636659f13df7e56dc32e44a7bb67c6028902210"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -15604,121 +10402,6 @@
     "program": "digits", 
     "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
     "revision": "2_fa286bf0bc8efacd555ccc78807667f5e3871fd9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "2_fa286bf0bc8efacd555ccc78807667f5e3871fd9"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "3_d67310f60c9a8fd530cb7767d68c61e234726b6d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "0_46856aa0a415d7023afa96849da5453f6ad389bb"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "5_26d503b34d412b7c03580678f4b7424d226d7881"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
-    "revision": "1_65f3856c4a209e1883517e497435ae8639c3dfdf"
   }, 
   {
     "bugclasses": [
@@ -15839,143 +10522,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "37593ded898de551d1f1a1e71d862d06a14049f3aefa1910057604fed896fab1dcabd08db9ed0f2f21f62b2335c6a8af771e9a80102c3384257696c14acea4a4", 
-    "revision": "2_5ab89018e36ef6f6f47ebba5762989d2ae02c9cc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "37593ded898de551d1f1a1e71d862d06a14049f3aefa1910057604fed896fab1dcabd08db9ed0f2f21f62b2335c6a8af771e9a80102c3384257696c14acea4a4", 
-    "revision": "1_a2ab36a1cd2a56adff2609d6e3afd0df6b96edd5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "timeout", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "37593ded898de551d1f1a1e71d862d06a14049f3aefa1910057604fed896fab1dcabd08db9ed0f2f21f62b2335c6a8af771e9a80102c3384257696c14acea4a4", 
-    "revision": "0_8c0e01baf6e4b6a345008c8686f843dfcfd5d3aa"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "298ef32ff8cf14be85e582657a295ea79462874300d4adfa295b7a84d14647e1b3624ed955c19403fb2f2ab928fa70ce869f84ff35ccbd7d1a999236f58a4bdf", 
-    "revision": "1_b05bff86dc39e75c36ed6fb77ff71f9051dcaab5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "298ef32ff8cf14be85e582657a295ea79462874300d4adfa295b7a84d14647e1b3624ed955c19403fb2f2ab928fa70ce869f84ff35ccbd7d1a999236f58a4bdf", 
-    "revision": "0_b82192c677e5beef194b8c58c056890fe5ac5c1a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "298ef32ff8cf14be85e582657a295ea79462874300d4adfa295b7a84d14647e1b3624ed955c19403fb2f2ab928fa70ce869f84ff35ccbd7d1a999236f58a4bdf", 
-    "revision": "1_b05bff86dc39e75c36ed6fb77ff71f9051dcaab5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
@@ -16072,216 +10618,12 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "d5cc7acaad4f01271abd8e5e7aecd52ad0fd82b2ea0c14dec8df934c2339b522dd2ed9549605a6405048bcbd89256e7ec818001899fecaa1ec147265783608f9", 
-    "revision": "3_b1a6ff6f46c31292fcf5bb100b056d5b976e652c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "8_ef6377ab6131b36aea346426e19feb036ccbc85d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "3_525083a9af06a5058dced1cb913d72922c7fe0b2"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "4_cd1babc5740c198f98e54da08f775e133f41c551"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "5_5030a930cc63b64c965741355ef0f537d048bcd4"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "7_4eaf64bb3f40b37de9a99731141ecac3ca4c3e62"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "9_c09b8349dd371b457ae316005304025cbeb111be"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "6_9a0b7d8fe0e6def5a7f3fd109207ac3ae2739027"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
     "program": "median", 
     "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
     "revision": "9_1cb0d91d55c34d85cb1f84a0f0970bac929a33be"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "1_b077387787b4270667eaeded14f6dec27c59b802"
   }, 
   {
     "bugclasses": [
@@ -16318,26 +10660,6 @@
     "program": "median", 
     "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
     "revision": "12_63dd3affb165f99fc7ecf50c1e6a382cae16ab15"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "3_cb8c1c357b3be52d1bd755e21498cff9c52badd3"
   }, 
   {
     "bugclasses": [
@@ -16395,46 +10717,6 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "0_4cc77f2ca081ae85ae412a87ae176b441cc62cde"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "4_243e3d36f0ed66b6c06facae4f3bd687418c17ce"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -16459,26 +10741,6 @@
     "program": "median", 
     "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
     "revision": "15_92807c57fc75f7beb838e848c07f82168b077846"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "2_278ffde554bfae66f1279bffb2b0bdfac12aedf3"
   }, 
   {
     "bugclasses": [
@@ -16595,133 +10857,10 @@
     "bugclasses": [
       "output mismatch"
     ], 
-    "program": "syllables", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "9_1835f125b113520be90fb013cbd66fc6bebf380d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch"
-    ], 
     "isReferenceDefect": true, 
     "program": "syllables", 
     "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
     "revision": "11_04e276312b9b80222cbaf484c56b309a6ec95f60"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "3_fe315e47b407ea90242500d6c0f0e9e66cb10dbf"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "5_cc014524c05554c108f2f24c9846fb726b8ed7a0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "4_a82393e14419ab4b649e36abaa36d3178e194435"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "6_903fd58b9b7a139c08c5dbb34feee8c2027bad82"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "2_db0404b5b5ad34e2ad4d88c9b65c913db138108b"
   }, 
   {
     "bugclasses": [
@@ -16945,75 +11084,6 @@
     "program": "digits", 
     "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
     "revision": "4_a82393e14419ab4b649e36abaa36d3178e194435"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "1_ceaa29ff38f79c012d7c867510f04998c6276adc"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "0_ad94a5ad361853b9ca19b6e2c00fadccd195a2d7"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "digits", 
-    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
-    "revision": "2_db0404b5b5ad34e2ad4d88c9b65c913db138108b"
   }, 
   {
     "bugclasses": [
@@ -17186,219 +11256,12 @@
   }, 
   {
     "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "5_6c8b39f11d8a9b186e2fc03ffd5c4abef49acaab"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "6_1b8ef8b887422de7a2eac2438258b442f5e51c3b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "0_575cfd8e47d4098dc747619ea4be075fd70b8944"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "7_4915da873f2b17ee38e73640d8ccf3d3b90f06b0"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "3_31f7ac3f059bf4b46c1e6dad32e6b16f44de83e4"
-  }, 
-  {
-    "bugclasses": [
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "smallest", 
     "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
     "revision": "9_7b62792ec0acd48855b640779d2bc9a36f6ff421"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "1_ac061364876cbb460d32b4f796eeee5ebea76c0d"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "4_1087a4522ca22d7fd0524fd5b7a0c246ea511c9a"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "8_9add6832e88ef9f7e27dde3d7519a13e60e80342"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "smallest", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "2_c72d928728339cbee560fdcb3b97eb1c6d0177f9"
   }, 
   {
     "bugclasses": [
@@ -17439,121 +11302,6 @@
     "program": "median", 
     "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
     "revision": "1_2905e12352bf767f7c1e78a56bbc105424cd6829"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "0_ffd9b8522a3bbb039e430e9a06997bc7e71a28d3"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "1_7eedd6863954ae639b0de498fe328875aff6ad6e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "3_a22803b06b29057bf7634db9c68646b19b0c794e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "2_51403fc8320bdf211acb3e9779374e1b7390d690"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "4_605e5416537e181c8b1ca5ae311094ae97bbefce"
   }, 
   {
     "bugclasses": [
@@ -17626,56 +11374,6 @@
     "program": "grade", 
     "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
     "revision": "12_4b090c2c0eff7e61172defdcdc2fddf4d5c1fe3b"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "1_2905e12352bf767f7c1e78a56bbc105424cd6829"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "3_65a9a59287d447a693bbb0487179b7a629508b8b"
   }, 
   {
     "bugclasses": [
@@ -17814,56 +11512,6 @@
       "output mismatch", 
       "output mismatch", 
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "2_d9041bce655564190e71a18963e934f80eeee8d5"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "5_07fe1fc4dc5fbe4840d6e146f8f4c84bf73a6c2c"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": false, 
@@ -17918,31 +11566,6 @@
     "program": "grade", 
     "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
     "revision": "11_3f37e0c5c3072544f512fe1888c058fe2f5e8ff8"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "grade", 
-    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
-    "revision": "4_1742efc55c26f440cc210d1d3c378865baea1863"
   }, 
   {
     "bugclasses": [
@@ -18024,29 +11647,6 @@
     "program": "median", 
     "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
     "revision": "0_6b14655a560728681c6e28c9b7144610e72fad3e"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "checksum", 
-    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
-    "revision": "0_5545c8783552f6d5d4adc180c5d4647e573501f4"
   }, 
   {
     "bugclasses": [
@@ -18340,26 +11940,6 @@
     "program": "median", 
     "repo": "af81ffd4bc47e4f84cbf87051d82d15af14833eaba6c57ae82fc503a67eb939f3e6552182124605c38a77a6774f41fac2cc95082320ba5e29d303277c098c4ae", 
     "revision": "0_1a7cdaa82eb31aa525c88f9995e4bb29d44c0460"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "median", 
-    "repo": "af81ffd4bc47e4f84cbf87051d82d15af14833eaba6c57ae82fc503a67eb939f3e6552182124605c38a77a6774f41fac2cc95082320ba5e29d303277c098c4ae", 
-    "revision": "5_40fdf17b952934c9d9d31aaa77d4f33f2cdc4fbc"
   }, 
   {
     "bugclasses": [
@@ -18684,57 +12264,1152 @@
   {
     "bugclasses": [
       "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "313d572e1f050451c688b97510efa105685fa275a8442f9119ce9b3f85f46e234cdf03593568e19798aed6b79c66f45c97be937d09b6ff9544f0f59162538575", 
-    "revision": "1_19d70665d1d6fad3954a113b8907d2e38054bd39"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch", 
-      "output mismatch"
-    ], 
-    "program": "syllables", 
-    "repo": "313d572e1f050451c688b97510efa105685fa275a8442f9119ce9b3f85f46e234cdf03593568e19798aed6b79c66f45c97be937d09b6ff9544f0f59162538575", 
-    "revision": "2_33edf05690adb684e4dc75311c29252dcfbc8966"
-  }, 
-  {
-    "bugclasses": [
-      "output mismatch", 
       "output mismatch"
     ], 
     "isReferenceDefect": true, 
     "program": "digits", 
     "repo": "313d572e1f050451c688b97510efa105685fa275a8442f9119ce9b3f85f46e234cdf03593568e19798aed6b79c66f45c97be937d09b6ff9544f0f59162538575", 
     "revision": "0_f2a5e508f134c75db35c54474b6acb238796bd8a"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "98d873cde39437ae581e6b61ce30ca54634c9c1517b46a0f2774cb12db474b5a37759281b19283c60dbcfa44ac3e05d474a896310f64e8533603b1db73457494", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "e79f832ff314d3658c07e164d7866db707eafc8c97f209cf1d5cdb3b0cfc6738e7bd533c426a4887122d853ffa152b8861f30c41642a180152ba50c983de66dc", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "833bd42c11f7407d63f604b8ba3b7927e22e04e91884c959f01083cda7d5019610705b94a89c09cd1caa3fd1d58eee24b48b85b523db0fa3fc302e7af2dff93d", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "d767ad3b58111a0515c8a380d3bf376038066f24de65f5f88606f956c354f1750f5dc2e8fd647dfbbdae7a8dd70f3d8b3345ba7075534b8ed3aa344789cf73c2", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "5b504b3547416bfd54f138b3caa529ad72d157744b787e0e6f4745a2ff0fc5cc33bc87904b2d7cda9c7858087b2e04ece46d53fe9edd208f68d30a0ae70f363f", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
+    "revision": "9"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
+    "revision": "15"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "a3d1771781cb82fd72bf708693ced00fccbec480c21c0e0dca5a3843fff6dfb92d3e68fc6d992cc7b76987e706875c6570936cb127216a3a8b437feba7772d14", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "f227ed285307815838e91975d2523300f5c71aa244356578858ac751ca351b55bc62f13559b03041faf2130fa8228dc0f8527f129e516404f37d4940707125b1", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "dc11fbc9421c547961bfefcdc4044715a7131ceb484b10c8391745399298fcce81022dbb780a9efcac004486b7d989ef4bf0dfb5a4db7c599a8f9aa3393570ae", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "f5b56c79c624eac7c37c45c1540916bb9b5f5db93e2a426a282a5d0eacde86b4b1e5d1d119eeb06f0ead94d2e4f228dca8dde4ef511af4bc59a18d272d820a0e", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "1b31fa5c50f7725ce468ebf24282f2d080a83aed87e4ee35522ae7710c8e0136bc263cc460b8ec7bf2c3519cb59af4a138e114d36541515b2609ab56ad2b8ee9", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "d120480a6e4bd3c4aa2ca882cf7c0aaa499d56c9c236aba6bea7aa935843da56c1ce494b71da9e2c2fd6016b05c84164bbd70867801caf480497fa51a3b78cb1", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "e9c74e27a17310a52842f7099c3e5c126298e1a08f2b841169cd5f155e6f2970d14d0314da1f6314ed970de1d20be306a60f0ce341d1c4d01300cc6efad7ab9b", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "d43d32076778e9cb3a2aa237e806bc00b0eaffde5b75563c9321019a817607f8303e6b982bf49358787264ac38e22026f27bde7e67a87ba43b973c29442f9e93", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "90a14c1ac8f56395389fade6f67872a9684e61f83099e634ac675eae04f391f3cc2b6f6ebe966f2488ce7e00a2cabb218f3b1372d4161b3c05d134b1b7f296d2", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "c9d718f379a877bd04e4544ee830a1c4c256bb4f104f214afd1ccaf81e7b25dea689895678bb1e6f817d8b0939eb175f8e847130f30a9a22e980d38125933516", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "1c2bb3a40a82cba97b2937bc6825903a28ecfe91f993fc177a0f2ae003bcc7b1073eb49e35d3f0f69d6b612e8347e9c1b93306bf25a7e5390098c1a06845baac", 
+    "revision": "9"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "9013bd3be8c00de447e6ed49a0fe0fab037251c28e26954bf780f2f3b929a9e7ce9da037811c76028e4069d3857410f82b8f399c7fa4386ea8f97f80aab1f191", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "6e464f2b5ba1d5ad3d4fc366e7d7712b424aabd8b41ca36257115a16416d202feb27397a413d04944c9ac76976fa8ff8ae646144855e08791ebf9593d1caaaca", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "d8b262849e28496f80a8acf7de9758cf3f3a4edf023343521e2e0ac50ec485212a473405570d6c58de6756ae098600d9c7138390faa1aaf6bf3609a8d4016448", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "digits", 
+    "repo": "af81ffd4bc47e4f84cbf87051d82d15af14833eaba6c57ae82fc503a67eb939f3e6552182124605c38a77a6774f41fac2cc95082320ba5e29d303277c098c4ae", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
+    "revision": "18"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "f5b56c79c624eac7c37c45c1540916bb9b5f5db93e2a426a282a5d0eacde86b4b1e5d1d119eeb06f0ead94d2e4f228dca8dde4ef511af4bc59a18d272d820a0e", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "5b504b3547416bfd54f138b3caa529ad72d157744b787e0e6f4745a2ff0fc5cc33bc87904b2d7cda9c7858087b2e04ece46d53fe9edd208f68d30a0ae70f363f", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "dc11fbc9421c547961bfefcdc4044715a7131ceb484b10c8391745399298fcce81022dbb780a9efcac004486b7d989ef4bf0dfb5a4db7c599a8f9aa3393570ae", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "36d8008b13f6475ca8fa4553fea10042b0a6c623665065672051445c3464d61b29b47cb66321844a0264505a0f5ccf5aa6de072aa266b5a8b0cf13198380a389", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "98d873cde39437ae581e6b61ce30ca54634c9c1517b46a0f2774cb12db474b5a37759281b19283c60dbcfa44ac3e05d474a896310f64e8533603b1db73457494", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
+    "revision": "16"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "531924c0915a9fa7b02951d5de7cc2b0da19d57a6be3b667c064bec1d5db14b955c30483b24273dd8d11a609a81726c4e6ab964009eb716f8b60adcf5f6fd7e8", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "295afd8942816e14193424cec0b9802cea194a90b13253b85fd19b6caeada3830c60f1fb2fbbdc67a8f713be54b01a6ea116a7d206800df226d6285ece3a4736", 
+    "revision": "14"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "489253253c866aa61b6b0d95c6072d3912f6b78dfbc01bdb2fbb663aefe33d6d353b1a61bb5fc567c9d6c334994111816edd3d43db47e4ea4a84953198736ff7", 
+    "revision": "12"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "68ea5d3466c7a9fb4a9219015d32f37de45f50df920793d79bc6028242a1913e9fa55a6da8262f1bc1f64b15e481dcd74d30dc36a54704a8abeac07d06f0f591", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "833bd42c11f7407d63f604b8ba3b7927e22e04e91884c959f01083cda7d5019610705b94a89c09cd1caa3fd1d58eee24b48b85b523db0fa3fc302e7af2dff93d", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
+    "revision": "9"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "b1924d63a2e25b7c8d9a794093c4ae97fdceec9e0ea46b6a4b02d9a18b9ba9cecf07cb0c42c264a0947aec22b0bacff788a547a8250c2265f601581ab545bf82", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "d8b262849e28496f80a8acf7de9758cf3f3a4edf023343521e2e0ac50ec485212a473405570d6c58de6756ae098600d9c7138390faa1aaf6bf3609a8d4016448", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "ee1f20ccded21df47f14019584a29968013d1e66c8df14c1564aff0d69f463c1897e93b7881fa6318cbf475b51e0cdd7523d748525fb5d64d376b88614d3fc92", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "387be36eafae90e7b26450a56b535f6779e881ed8916bbab08bceeb78d8ea474757d46977e2943e6b07dfe150757f53679b911e113ef68a13cd1e75b3daf18d7", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "92b7dd1241c2688476a763b691eadd80a1aa750e7c26955f8c3a3d2b11233c05cd51469a029d22c1ba0b6b4203484f2d056d1bdf5cef075f583fbca4292f1a40", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "e23b96b6bab26bd14316cefafcbaa16dd8eafcfb97a7159a7772f3c8bb3e78fb353dea728f6b4df6528286af5f0b85fd134c79886c9c2a352fe80d8204c69111", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "769cd811312cbbb82c87033a78ac9584ad282550bcb9cc3ae8c4e3da44c288c1a5b3954e01998c3c0654ee6774ceab66e9fe5b135750905c917d2b0bb5fab98b", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "0cea42f9680f35f5a84c724c396d4d588b65c303453f9585562f2e2af8db74f5096a83a70b17c5126538222b111a0795a34e9fb6db95d62d771d01592abe3ff6", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "cb243bebea400595cc274d1246f3307c507ba6a0e891f6e318cde2b80a72de40dab19eb7f76d3b6573a08e446bce6fb4435cdb016ae6489973b855a9bddd3b11", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "1c2bb3a40a82cba97b2937bc6825903a28ecfe91f993fc177a0f2ae003bcc7b1073eb49e35d3f0f69d6b612e8347e9c1b93306bf25a7e5390098c1a06845baac", 
+    "revision": "16"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "6e464f2b5ba1d5ad3d4fc366e7d7712b424aabd8b41ca36257115a16416d202feb27397a413d04944c9ac76976fa8ff8ae646144855e08791ebf9593d1caaaca", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
+    "revision": "21"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "8ce6345ea4e815b04769b3920f04becec20cf8051565f087aa5e03c5fdca4752a56cbec48207b74f69db55f0e9e0c3c28809cc228c8d6637a7a9c732977640b9", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "d009aa71ece41454c68d8038b5462d8eea8feb291bce1d53ee149f8477b5eab62ee28c7f690bf14dc6ce1d70c8943f7f3b3e4300965cb24da4cd2d2807dab19a", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "af81ffd4bc47e4f84cbf87051d82d15af14833eaba6c57ae82fc503a67eb939f3e6552182124605c38a77a6774f41fac2cc95082320ba5e29d303277c098c4ae", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
+    "revision": "15"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "grade", 
+    "repo": "9c9308d4cdf5bc5dfe6efc2b1a9c9bc9a44fbff73c5367c97e3be37861bbb3ba9ac7ad3ddec74dc66e34fe8f0804e46186819b4e90e8f9a59d1b82d9cf0a6218", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "ca94e3756cbf8d1490bad660c06307f5d678e3675bbea85359523809a4f06b370066767ea2d2d76d270e4712b464924f12e19dbf1a12d28b75d367ceb202dbb9", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "e23b96b6bab26bd14316cefafcbaa16dd8eafcfb97a7159a7772f3c8bb3e78fb353dea728f6b4df6528286af5f0b85fd134c79886c9c2a352fe80d8204c69111", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "a0e3fdae706d528dcf146cbad986ba9fd834440a7b500e32f04fad073e955a46e481c713ee118432f3fd5dfa1a63fc1caefd648a56a389e40e6362dfd51625b0", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "d43d32076778e9cb3a2aa237e806bc00b0eaffde5b75563c9321019a817607f8303e6b982bf49358787264ac38e22026f27bde7e67a87ba43b973c29442f9e93", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "08c7ea4ac39aa6a5ab206393bb4412de9d2c365ecdda9c1b391be963c1811014ed23d2722d7433b8e8a95305eee314d39da4950f31e01f9147f90af91a5c433a", 
+    "revision": "15"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "36d8008b13f6475ca8fa4553fea10042b0a6c623665065672051445c3464d61b29b47cb66321844a0264505a0f5ccf5aa6de072aa266b5a8b0cf13198380a389", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "d5cc7acaad4f01271abd8e5e7aecd52ad0fd82b2ea0c14dec8df934c2339b522dd2ed9549605a6405048bcbd89256e7ec818001899fecaa1ec147265783608f9", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "75c98d3d90ca9a022bbf45421aa04a07f37da8a126811259bc4873e9458baab0a4863fa6664e5735c60172b34a16ed5acef892635f4f16e6d5737fb3685d0356", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "cb243bebea400595cc274d1246f3307c507ba6a0e891f6e318cde2b80a72de40dab19eb7f76d3b6573a08e446bce6fb4435cdb016ae6489973b855a9bddd3b11", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "e9c74e27a17310a52842f7099c3e5c126298e1a08f2b841169cd5f155e6f2970d14d0314da1f6314ed970de1d20be306a60f0ce341d1c4d01300cc6efad7ab9b", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "2c1556672751734adf9a561fbf88767c32224fca14a81e9d9c719f18d0b21765038acc16ecd8377f74d4f43e8c844538161d869605e3516cf797d0a6a59f1f8e", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "checksum", 
+    "repo": "98d873cde39437ae581e6b61ce30ca54634c9c1517b46a0f2774cb12db474b5a37759281b19283c60dbcfa44ac3e05d474a896310f64e8533603b1db73457494", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "c716ee619761838749589cbd08d5fd56830bff349039f8587e988a5b0cd6310e04844d8e0ee98c5ffee3275aa227bd2c92fcde0993637fcf3bfbd41a37378833", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "d2b889e1ac42bc85f9df5c45c10708f46784be93d69acd1415cfd4d028cb50b19f50c374a9498c8e8b909173053a100e20c279ddb06c6359a06a920ead3e8080", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "317aa7055d3b7337ab43b73863692d1288ca246c473f9fd176bc737a7c3e1e08c37a15603cfb7bfc86f7bc2dcc239967b79b605aec11f86ae3ab90dc140b540f", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "89b1a701f92f7e190fd4caf2ad32365f2c9261790b9a33967efd0bfb4d047c721db673225a01819900d542401a0b95d29db7ff0d8548087faabd4230f896474f", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "d25c714b0bf59a479cfefe89ae1a98cf00937dccbe68f02fb160f1f561c967d01a00b4b0ef23c9eb1bd2a5667b48ed78e484802b21672ab946b354ff7a6027c7", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "d4aae191327d63b5ebc388f4bdbdaaf670e3332ea6afc5be3f04cca42334a4b6fe038630379bb774135a21197172563cf1b684c6ae927cce50b06340048b132a", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "d120480a6e4bd3c4aa2ca882cf7c0aaa499d56c9c236aba6bea7aa935843da56c1ce494b71da9e2c2fd6016b05c84164bbd70867801caf480497fa51a3b78cb1", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "9083480332b4a5e4274f3bf5ef8bd5d1bd75048c0c066e574c27a2de6d919d658efc519e8b6a230a074eb5f2957d5768f4dc981a8e926c3a72993bc448a017f7", 
+    "revision": "18"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "1c2bb3a40a82cba97b2937bc6825903a28ecfe91f993fc177a0f2ae003bcc7b1073eb49e35d3f0f69d6b612e8347e9c1b93306bf25a7e5390098c1a06845baac", 
+    "revision": "16"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "af81ffd4bc47e4f84cbf87051d82d15af14833eaba6c57ae82fc503a67eb939f3e6552182124605c38a77a6774f41fac2cc95082320ba5e29d303277c098c4ae", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "9c9308d4cdf5bc5dfe6efc2b1a9c9bc9a44fbff73c5367c97e3be37861bbb3ba9ac7ad3ddec74dc66e34fe8f0804e46186819b4e90e8f9a59d1b82d9cf0a6218", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "fcf701e8bed9c75a4cc52a990a577eb0204d7aadf138a4cad08726a847d66e77126f95f06f839ec9224b7e8a887b873fe0d4b6f4311b4e8bd2a36e5028d1feca", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "median", 
+    "repo": "0cdfa335eea3c612e6fa3ad261276b0c3ebbc6ff0ff13c20bdc249bad29a8037ca6dc887dd28558964e1e1a24f47c4cffc05adba525285dc8b93660cdf9b8b7c", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "d009aa71ece41454c68d8038b5462d8eea8feb291bce1d53ee149f8477b5eab62ee28c7f690bf14dc6ce1d70c8943f7f3b3e4300965cb24da4cd2d2807dab19a", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "070455301c2e18c7c89b850c2e86c311ac5fd223c84e723591012e163d60f11f5fd030343a444049a44940f8607d36c463f30556bf1efa98916d7417c2b4393c", 
+    "revision": "10"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
+    "revision": "18"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "30074a0e036669b5681720e6481cc101877d52ee589bab434417ece22b4133ed584c6a84f80047c10ab47aa73a7807720b5375983e8b489e8e69978e5e0e8b71", 
+    "revision": "15"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "1b31fa5c50f7725ce468ebf24282f2d080a83aed87e4ee35522ae7710c8e0136bc263cc460b8ec7bf2c3519cb59af4a138e114d36541515b2609ab56ad2b8ee9", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "e9c6206d3a4862876b0dead881ac55078f11e291f60215ab028651f06fcbee2a591a31a7727037774542df4fe051a89460d85f6067a0b9729ae86e4afe1e6e92", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "68eb0bb00bcd06020ba4e5c5afbce504f5e7af9618c274197da7d50f668649a59f3eb961a718f5f67cc8731f9f5e2df46e511d083b2b5e785e9377c8f94e6ea5", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "3b2376ab97bb5d1a5dbbf2b45cf062db320757549c761936d19df05e856de894e45695014cd8063cdc22148b13fa1803b3c9e77356931d66f4fbec0efacf7829", 
+    "revision": "16"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
+    "revision": "13"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "median", 
+    "repo": "98d873cde39437ae581e6b61ce30ca54634c9c1517b46a0f2774cb12db474b5a37759281b19283c60dbcfa44ac3e05d474a896310f64e8533603b1db73457494", 
+    "revision": "8"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "fe9d5fb933c758c2cbbd859e3ecbd2d2eaecc2843b57cfd97da99af24de59f189a144d13ce81ec585d7c2f7367f70c0fb2aec8269eed1fd8380def614817ef7c", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "c868b30a4adebf62b0ed20170a14ee9e5f8bc62d827e9712294ffa4a10ab8423e3d903c29e2392c83963972019a470e667c1987e2547294d1e2d1df1db832912", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "b1924d63a2e25b7c8d9a794093c4ae97fdceec9e0ea46b6a4b02d9a18b9ba9cecf07cb0c42c264a0947aec22b0bacff788a547a8250c2265f601581ab545bf82", 
+    "revision": "7"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "cb243bebea400595cc274d1246f3307c507ba6a0e891f6e318cde2b80a72de40dab19eb7f76d3b6573a08e446bce6fb4435cdb016ae6489973b855a9bddd3b11", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "smallest", 
+    "repo": "f94e261284a925b931cca5a89f73ae19039f2699f0416d5e4e7e673bb7a2c746760ae35adf47cfa94ad5af1623209b17a0e53c1300d3771c5b0b0cada1561d3f", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "95362737dcd262ddd67b0fe1381c25f1e6b885860b4e51efb6f57223dceb77b4c6c7d855e3fe891c10cd51b48c9b052cf2c74f181a28d3020d77a4a2d6e4db18", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "d9e7eab5f82342d78fb20833701c4e9f900e8fcb737038d3a2ad18f664532af4d6332b7d14841c9ac773c52f6590b754f76df1f430a35bc8ca4799a767cdec6d", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "smallest", 
+    "repo": "d9e7eab5f82342d78fb20833701c4e9f900e8fcb737038d3a2ad18f664532af4d6332b7d14841c9ac773c52f6590b754f76df1f430a35bc8ca4799a767cdec6d", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "5a5683598d8e2140d344e9ac96a8d6105b8e6e55831ab874cd960dfe789c3b242d57aad028e2b28331e4d61019d6e1b1d1cad97316bcb0378df48de738147b7d", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "346b1d3c1cdc3032d07222a8a5e0027a2abf95bb1697b9d367d7cca7db1af769d8298e232c56471a122f05e87e79f4bd965855c9c0f8b173ebc0ef5d0abebc7b", 
+    "revision": "15"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "6aaeaf2ffb623b5736c0c0b9e8a1a3b080e8aef14d963d899eb3e4073245ad1171e26fb2a64fb88db6e40aa59e894a55eac832e38d444755cb3b6ad10ba74c62", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "818f8cf4e2e713753d02db9ee70a099b71f2a5a6bdc904191cf9ba68cfa5f64328464dccdd9b02fe0822e14a403dc196fe88b9964969409e60c93a776186a86a", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "smallest", 
+    "repo": "769cd811312cbbb82c87033a78ac9584ad282550bcb9cc3ae8c4e3da44c288c1a5b3954e01998c3c0654ee6774ceab66e9fe5b135750905c917d2b0bb5fab98b", 
+    "revision": "11"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "c9d718f379a877bd04e4544ee830a1c4c256bb4f104f214afd1ccaf81e7b25dea689895678bb1e6f817d8b0939eb175f8e847130f30a9a22e980d38125933516", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "dedc2a7c919835ade6d92729cfb18fc71addf6dcdf36ce26ca8b1e3d3aea81bad974c61b96fd71537e95a6aac4582d5b08f9fd8057ce40fb18fb5df37d86b70d", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "dedc2a7c919835ade6d92729cfb18fc71addf6dcdf36ce26ca8b1e3d3aea81bad974c61b96fd71537e95a6aac4582d5b08f9fd8057ce40fb18fb5df37d86b70d", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "f8d57deac89e46f99354a70e8f6bc830e0bded0c297d7a0765348de79d6071cb076d4e8f2cd60cff584cb220049d6065827a29904a7e1f9144f510f7773e6d0e", 
+    "revision": "3"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "97f6b15278788d90f6a0159ac65668f63f182fadf165e78bfecd7750de89f8611759f8d8206b3505407f7de14d124db7b0309a53e222c538c4dedadc6fa24fe6", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "824eb077ad12f1d09c072e46b02fd0a9a605d9c527b8c9de6ef22b674982933a26784bd60162bd814b2d453c4196c41e9451019dcd671946a32f44a733c75978", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "48b82975576f07f162163145b334648a73321d003a0a8cd4577172e48ce4836e63953dffd4460a9a7aadc511a695ff93de0ce2baf953e4b78b747440caa736a6", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "dc11fbc9421c547961bfefcdc4044715a7131ceb484b10c8391745399298fcce81022dbb780a9efcac004486b7d989ef4bf0dfb5a4db7c599a8f9aa3393570ae", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "dc11fbc9421c547961bfefcdc4044715a7131ceb484b10c8391745399298fcce81022dbb780a9efcac004486b7d989ef4bf0dfb5a4db7c599a8f9aa3393570ae", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "98d873cde39437ae581e6b61ce30ca54634c9c1517b46a0f2774cb12db474b5a37759281b19283c60dbcfa44ac3e05d474a896310f64e8533603b1db73457494", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "e9c74e27a17310a52842f7099c3e5c126298e1a08f2b841169cd5f155e6f2970d14d0314da1f6314ed970de1d20be306a60f0ce341d1c4d01300cc6efad7ab9b", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "d767ad3b58111a0515c8a380d3bf376038066f24de65f5f88606f956c354f1750f5dc2e8fd647dfbbdae7a8dd70f3d8b3345ba7075534b8ed3aa344789cf73c2", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "d767ad3b58111a0515c8a380d3bf376038066f24de65f5f88606f956c354f1750f5dc2e8fd647dfbbdae7a8dd70f3d8b3345ba7075534b8ed3aa344789cf73c2", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "ca5057661022789c0b40bc1574ab8b0826b3d22f70de1a10b2d2122137774c6aec73fe789a94b2362628481da623120033956bd376b41b825a72dbd8b50aff2f", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "d120480a6e4bd3c4aa2ca882cf7c0aaa499d56c9c236aba6bea7aa935843da56c1ce494b71da9e2c2fd6016b05c84164bbd70867801caf480497fa51a3b78cb1", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "d120480a6e4bd3c4aa2ca882cf7c0aaa499d56c9c236aba6bea7aa935843da56c1ce494b71da9e2c2fd6016b05c84164bbd70867801caf480497fa51a3b78cb1", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "38eb99ca5f527278e523bc9e14ee447c514f13c29f3b7f61282f1698d96b6f45a55f77275f23f8d1e6b23527e590dd9c11b290a9c04121720fb31a1405e19022", 
+    "revision": "6"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "035fe90b24b4ff56975fbd6242879bdfd422686189d7fedadb2ba64bb9820150b501dc681379bff2f1b0b2efd50a3dc272fea6fa3509cf3dfd088f8d0267888d", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "035fe90b24b4ff56975fbd6242879bdfd422686189d7fedadb2ba64bb9820150b501dc681379bff2f1b0b2efd50a3dc272fea6fa3509cf3dfd088f8d0267888d", 
+    "revision": "0"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "bfad6d21d636def8e9e72910c3eb0815f5747669e3a60fb10c6f7f421082d18e548dcfc5d4717bb6da075c36f067b37858d11528ce796b3226ae33719c5007ce", 
+    "revision": "4"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "7b78b2d5ab654253c4acb32046237950862d20275165bdb24a7584184a22d3cebeadb299f4e16fdf452f4dc6f958000d118d5ba60dea5645d143183573109d58", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "7b78b2d5ab654253c4acb32046237950862d20275165bdb24a7584184a22d3cebeadb299f4e16fdf452f4dc6f958000d118d5ba60dea5645d143183573109d58", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
+    "revision": "17"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "d9e7eab5f82342d78fb20833701c4e9f900e8fcb737038d3a2ad18f664532af4d6332b7d14841c9ac773c52f6590b754f76df1f430a35bc8ca4799a767cdec6d", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "93f87bf20be12abd3b52e14015efb6d78b6038d2022e0ab5889979f9c6b6c8c757d6b5a59feae9f8415158057992ae837da76609dc156ea76b5cca7a43a4678b", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": false, 
+    "program": "syllables", 
+    "repo": "3cf6d33ab0357953aa5826c67dc74c4aa483f16ef04c973a68d58cda6f19ea712954b24f366f880b9c18b628c6605eabc4d3e80dc4aa120fac80fe680e2e708f", 
+    "revision": "2"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "b6fd408d589fd1cce4003e2cf601a028e3c01042c8a274ddc384a1524cab2014154932e9cb48312af6af394ee6bee85603cab8dad3c9617a49b9d14dc482b578", 
+    "revision": "1"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "cd2d9b5b5cff96b07c5b22c0d139ffa2aa36b01823c9eb4db6eca19065a0ce2c4d2516bfcc2f1bc95daeae5b0bbd5e9c15b83feda776735e7bc3de6c49d25144", 
+    "revision": "5"
+  }, 
+  {
+    "bugclasses": [], 
+    "isReferenceDefect": true, 
+    "program": "syllables", 
+    "repo": "ea67b84145a12733c524b716da44f36a42cf815013d14cafbd2a66a5a4c8b5a99022c355960cd62ca71a640315747cd604afdfa9ec753d1739c686734b2798a7", 
+    "revision": "7"
   }
 ]


### PR DESCRIPTION
This PR removes all entries which does not exist in the dataset and adds the entries that are present in the dataset but not in the `defect-classification.json`file.

Note: the added entries does not have a `bugclasses` neither a complete `revision` id.
